### PR TITLE
Add additional "IDE" category and templates to handbook

### DIFF
--- a/docs/IDE/Notepad++/Notepad++.md
+++ b/docs/IDE/Notepad++/Notepad++.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Notepad++
+nav_order: 1
+has_children: true
+permalink: docs/Notepad++
+---
+
+{{ page.title }}
+======================
+
+//Content

--- a/docs/IDE/VisualStudioCode/VisualStudioCode.md
+++ b/docs/IDE/VisualStudioCode/VisualStudioCode.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Visual Studio Code
+nav_order: 1
+has_children: true
+permalink: docs/IDE/VisualStudioCode
+---
+
+{{ page.title }}
+======================
+
+//Content
+


### PR DESCRIPTION
Added:
- IDE/Notepad++
- IDE/VSCode

Moved:
- VisualStudio -> IDE/VisualStudio