### PR TITLE
ADDED: Profile Pictures For Contributors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # Programming Handbook
 
-<a href=""> 
-  <img align="left" alt="Open Source Project" src="https://img.shields.io/badge/Open%20Source%20Project-black?style=for-the-badge&logo=none&logoColor=white&color=black&labelColor=black"> 
+<a href="">
+  <img align="left" alt="Open Source Project" src="https://img.shields.io/badge/Open%20Source%20Project-black?style=for-the-badge&logo=none&logoColor=white&color=black&labelColor=black">
 </a>
 
 <br></br>
@@ -22,13 +22,15 @@ The Programmer's Handbook is an open source initiative to collect, archive, and 
 
 If you'd like to contribute to the project, please fork it, add your article, and submit a PR for review!
 
------------------------------------------------------------------------
+---
 
 ### Repository Maintainers
+
 - VerzatileDev
 - JDSherbert
 
 ### Contributors
-- VerzatileDev
-- JDSherbert
-- Sommos
+
+<a href="https://github.com/VerzatileDevOrg/Programming_HandBook/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=VerzatileDevOrg/Programming_HandBook" />
+</a>


### PR DESCRIPTION
Profile pictures added to the `Contributors` section of the main README, and should reroute users on click to the contributors graph.