### PR TITLE
[FIX] Web Build Error (Dependency Issue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,5 @@ jobs:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Install dependencies
-        run: |
-          bundle install
       - name: Build with Jekyll
         run: bundle exec jekyll build 


### PR DESCRIPTION
Previously there was an issue regarding the "Pre-Build" Of the website that goes through " CI " File under .github/workflows/ci.yml.

- Issue being that " Bundle " is already installed and used with the Theme Template and done by Github itself, which caused and error in establishing the build, See the changes from the following Request.
- For context See the error #18 

+ The issue was made by my @VerzatileDev  suggestion on @JDSherbert 's pull request, on where the workflow files were changed in the following https://github.com/VerzatileDevOrg/Programming_HandBook/commit/9a826e32e065f0e181845d4f859f8c27205e8cd4 