### PR TITLE
Correct Python content to Rust content.

### DIFF
--- a/docs/Language/Rust/Rust.md
+++ b/docs/Language/Rust/Rust.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Python
+title: Rust
 nav_order: 1
 parent: Language
 has_children: false


### PR DESCRIPTION
As described - changed title from Python to Rust.

Closes https://github.com/VerzatileDevOrg/Programming_HandBook/issues/32