### PR TITLE
[ADD] Back To Top (B), SINCE: Date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,7 @@ source 'https://rubygems.org'
 gem "jekyll", "~> 4.3.2" # installed by `gem jekyll`
 # gem "webrick"        # required when using Ruby >= 3 and Jekyll <= 4.2.2
 
-gem "just-the-docs", "0.6.2" # pinned to the current release
+gem "just-the-docs", "0.6.2" # pinned to the current Release
 # gem "just-the-docs"        # always download the latest release
+
+gem 'jekyll-last-modified-at', '~> 1.1' # pinned to the current Release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,9 @@ GEM
       webrick (~> 1.7)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-last-modified-at (1.3.0)
+      jekyll (>= 3.7, < 5.0)
+      posix-spawn (~> 0.3.9)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-seo-tag (2.8.0)
@@ -56,6 +59,7 @@ GEM
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.15)
     public_suffix (5.0.3)
     rake (13.0.6)
     rb-fsevent (0.11.2)
@@ -79,6 +83,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.3.2)
+  jekyll-last-modified-at (~> 1.1)
   just-the-docs (= 0.6.2)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -8,3 +8,12 @@ github_base_url: "https://github.com/VerzatileDevOrg/Programming_HandBook"
 
 aux_links:
   Contribute to the Github Repository: https://github.com/VerzatileDevOrg/Programming_HandBook
+
+back_to_top: true # Works through Footer.html
+
+plugins:
+  - jekyll-last-modified-at
+
+# Optional. The default date format, used if none is specified in the tag.
+last-modified-at:
+    date-format: '%d/%m/%Y'

--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -1,7 +1,20 @@
 <div class="footer">
-    <hr>
+  <hr>
+
+  {% if site.back_to_top %}
     <p>
-      <strong>Noticed A Mistake?</strong>
-      Click <a href="{{ site.github_base_url }}/blob/main{{ page.dir }}{{ page.name | replace: '_', '-' }}" target="_blank">here</a> to contribute!
+      <a href="#top" id="back-to-top">Back to Top</a>
     </p>
-  </div>
+  {% endif %}
+  
+  {% if page.last_modified_at %}
+    <p>
+      <strong>SINCE:</strong> {{ page.last_modified_at | date: '%d/%m/%Y' }}
+    </p>
+  {% endif %}
+
+  <p>
+    <strong>Noticed A Mistake?</strong>
+    Click <a href="{{ site.github_base_url }}/blob/main{{ page.dir }}{{ page.name | replace: '_', '-' }}" target="_blank">here</a> to contribute!
+  </p>
+</div>


### PR DESCRIPTION
[ADD]
-- Button -- 
   
     An option to scroll back to the top, to avoid doom scrolling manually on longer Content pages.

-- SINCE: Date --


    Edit Date now is using a dependency Pluging, captures the editing date of the given file.

    Installed in the GemFile, uploaded to gemfile.lock

    Plugin is called in config.yml as a plugin and optional Date Format is included
    if it might miss on the page " Currently globally declared for each page through "footer.html"

    !! Used through Footer.html !! 
     to ask for the given date and specify for each file.

References are listed as the following for this plugin.
#https://github.com/gjtorikian/jekyll-last-modified-at 

Currently It is missing the Author, see additional information that might come in handy from the "Report" #40 