### PR TITLE
Language specific examples

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,6 @@
 ---
 layout: table_wrappers
+include_language_switch_script: false
 ---
 
 <!DOCTYPE html>
@@ -7,35 +8,57 @@ layout: table_wrappers
 <html lang="{{ site.lang | default: 'en-US' }}">
 {% include head.html %}
 <body>
+  <!-- Skip to main content link for accessibility -->
   <a class="skip-to-main" href="#main-content">Skip to main content</a>
+
+  <!-- Include icons and sidebar components -->
   {% include icons/icons.html %}
   {% include components/sidebar.html %}
+
+  <!-- Main content section -->
   <div class="main" id="top">
     {% include components/header.html %}
+
+    <!-- Main content wrapper with breadcrumbs -->
     <div class="main-content-wrap">
       {% include components/breadcrumbs.html %}
+
+      <!-- Main content container -->
       <div id="main-content" class="main-content">
         <main>
+          <!-- Include anchor headings for heading links -->
           {% if site.heading_anchors != false %}
             {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
           {% else %}
             {{ content }}
           {% endif %}
 
+          <!-- Include children navigation if page has children and TOC is enabled -->
           {% if page.has_children == true and page.has_toc != false %}
             {% include components/children_nav.html %}
           {% endif %}
         </main>
+
+        <!-- Include site footer -->
         {% include components/footer.html %}
       </div>
     </div>
+
+    <!-- Include search footer if search is enabled -->
     {% if site.search_enabled != false %}
       {% include components/search_footer.html %}
     {% endif %}
   </div>
 
+  <!-- Include Mermaid diagrams if enabled -->
   {% if site.mermaid %}
     {% include components/mermaid.html %}
+  {% endif %}
+
+  <!-- Includes Button switch to change from one Programming Language to another (Must be Enabled Or won't be possible) -->
+  <!-- To Enable use " include_programming_language_switch_script: true " on .md pages  -->
+  {% if page.include_programming_language_switch_script %}
+    <script src="{{ '/assets/js/programmingLanguageSwitch.js' | relative_url }}" defer></script>
   {% endif %}
 </body>
 </html>

--- a/assets/js/programmingLanguageSwitch.js
+++ b/assets/js/programmingLanguageSwitch.js
@@ -1,0 +1,61 @@
+// Set the language preference in localStorage and update the displayed content immediately
+function setLanguagePreference(language, pagePath) {
+    // Set language preference in localStorage
+    localStorage.setItem('languagePreference_' + pagePath, language);
+    // Update the displayed content based on the selected language
+    showContent(language, pagePath);
+}
+
+// Get the language preference from localStorage
+function getLanguagePreference(pagePath) {
+    return localStorage.getItem('languagePreference_' + pagePath);
+}
+
+// Show the content based on the selected language
+function showContent(language, pagePath) {
+    // Map each language to its corresponding content element
+    var contentMap = {
+        'cpp': 'cppContent',
+        'csharp': 'csharpContent',
+        'python': 'pythonContent'
+    };
+
+    // Iterate over each language in the contentMap
+    Object.keys(contentMap).forEach(function (key) {
+        // Get the content element based on the language
+        var contentElement = document.getElementById(contentMap[key]);
+
+        // Check if the content element exists
+        if (contentElement) {
+            // Set the display property based on whether it's the selected language
+            contentElement.style.display = (language === key) ? 'block' : 'none';
+        }
+    });
+
+    // Log a message indicating the switch to the specified language
+    console.log(`Switching to ${language} content`);
+}
+
+// Perform actions after the DOM has fully loaded
+document.addEventListener('DOMContentLoaded', function () {
+    // Get the current page path
+    var pagePath = window.location.pathname;
+    console.log('Page Path:', pagePath);
+
+    // Retrieve the saved language preference from localStorage
+    var savedLanguage = getLanguagePreference(pagePath);
+    console.log('Saved Language:', savedLanguage);
+
+    // If a language preference is saved, update the displayed content
+    if (savedLanguage) {
+        showContent(savedLanguage, pagePath);
+    }
+});
+
+// Set the language preference and update the displayed content on button click
+function setLanguageAndShowContent(language) {
+    // Get the current page path
+    var pagePath = window.location.pathname;
+    // Set the language preference in localStorage and update the displayed content
+    setLanguagePreference(language, pagePath);
+}

--- a/docs/Concepts/Memory.md
+++ b/docs/Concepts/Memory.md
@@ -4,12 +4,26 @@ title: Memory
 nav_order: 1
 parent: Concepts
 has_children: false
+include_programming_language_switch_script: true
 ---
 
 {{ page.title }}
 ======================
 
 {% include under_construction.html %}
+
+<div id="cppContent">
+  <!-- Your default C++ content goes here -->
+  This is C++ content for Object-Oriented Programming.
+</div>
+
+<div id="csharpContent" style="display:none;">
+  <!-- Your C# content goes here -->
+  This is C# content for Object-Oriented Programming.
+</div>
+
+<button onclick="setLanguageAndShowContent('cpp')">C++</button>
+<button onclick="setLanguageAndShowContent('csharp')">C#</button>
 
 
 <br>

--- a/docs/Concepts/OOP.md
+++ b/docs/Concepts/OOP.md
@@ -4,6 +4,7 @@ title: OOP
 nav_order: 1
 parent: Concepts
 has_children: false
+include_programming_language_switch_script: true
 ---
 
 {{ page.title }}
@@ -21,34 +22,11 @@ has_children: false
   This is C# content for Object-Oriented Programming.
 </div>
 
-<button onclick="showContent('cpp')">C++</button>
-<button onclick="showContent('csharp')">C#</button>
+<div id="pythonContent" style="display:none;">
+  <!-- Your C# content goes here -->
+  This is python content for Object-Oriented Programming.
+</div>
 
-<script>
-  function setLanguagePreference(language) {
-    localStorage.setItem('languagePreference', language);
-  }
-
-  function getLanguagePreference() {
-    return localStorage.getItem('languagePreference');
-  }
-
-  function showContent(language) {
-    setLanguagePreference(language);
-
-    if (language === 'cpp') {
-      document.getElementById('cppContent').style.display = 'block';
-      document.getElementById('csharpContent').style.display = 'none';
-    } else if (language === 'csharp') {
-      document.getElementById('cppContent').style.display = 'none';
-      document.getElementById('csharpContent').style.display = 'block';
-    }
-  }
-
-  document.addEventListener('DOMContentLoaded', function () {
-    var savedLanguage = getLanguagePreference();
-    if (savedLanguage) {
-      showContent(savedLanguage);
-    }
-  });
-</script>
+<button onclick="setLanguageAndShowContent('cpp')">C++</button>
+<button onclick="setLanguageAndShowContent('csharp')">C#</button>
+<button onclick="setLanguageAndShowContent('python')">Python</button>

--- a/docs/Concepts/OOP.md
+++ b/docs/Concepts/OOP.md
@@ -25,7 +25,17 @@ has_children: false
 <button onclick="showContent('csharp')">C#</button>
 
 <script>
+  function setLanguagePreference(language) {
+    localStorage.setItem('languagePreference', language);
+  }
+
+  function getLanguagePreference() {
+    return localStorage.getItem('languagePreference');
+  }
+
   function showContent(language) {
+    setLanguagePreference(language);
+
     if (language === 'cpp') {
       document.getElementById('cppContent').style.display = 'block';
       document.getElementById('csharpContent').style.display = 'none';
@@ -34,4 +44,11 @@ has_children: false
       document.getElementById('csharpContent').style.display = 'block';
     }
   }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var savedLanguage = getLanguagePreference();
+    if (savedLanguage) {
+      showContent(savedLanguage);
+    }
+  });
 </script>

--- a/docs/Concepts/OOP.md
+++ b/docs/Concepts/OOP.md
@@ -11,7 +11,27 @@ has_children: false
 
 {% include under_construction.html %}
 
+<div id="cppContent">
+  <!-- Your default C++ content goes here -->
+  This is C++ content for Object-Oriented Programming.
+</div>
 
-<br>
+<div id="csharpContent" style="display:none;">
+  <!-- Your C# content goes here -->
+  This is C# content for Object-Oriented Programming.
+</div>
 
-<br>
+<button onclick="showContent('cpp')">C++</button>
+<button onclick="showContent('csharp')">C#</button>
+
+<script>
+  function showContent(language) {
+    if (language === 'cpp') {
+      document.getElementById('cppContent').style.display = 'block';
+      document.getElementById('csharpContent').style.display = 'none';
+    } else if (language === 'csharp') {
+      document.getElementById('cppContent').style.display = 'none';
+      document.getElementById('csharpContent').style.display = 'block';
+    }
+  }
+</script>


### PR DESCRIPTION
**++ PLEASE Read the changes carefully and comments specified under the post ++**

## [ADDRESSING] - @JDSherbert 
**Discussion in Issue " #25 ":**

In this issue, it was discussed that while the current "Concepts" folder contains examples, there's a need to enhance it by including examples in different languages instead of defaulting to the easiest option. This is particularly relevant where certain languages do not utilize specific concepts, like Object-Oriented Programming (OOP).

**Key points of discussion in Issue " #25 " include:**

1. **Default Language for Examples:**
   - There is a need to deliberate on establishing a default language for examples. This decision could impact the initial user experience and comprehension.

2. **Folder Structure and Organization:**
   - Consideration should be given to the organization of the folder structure. The question of whether to duplicate pages with language-specific examples or adopt an alternative approach is raised. This involves a strategic decision about the balance between simplicity and specificity.

3. **Implementation of Multiple Language Examples on the Same Page:**
   - Exploring the possibility of incorporating examples from multiple languages on a single page was discussed. The suggestion involves a potential solution of utilizing a dropdown to allow users to switch between different languages. This approach aims to provide a more versatile and inclusive learning experience.

**The following example implementation aims to address the aforementioned points:**

- Utilizes Javascript eventListener to initially store a user's preference locally when they first request the site, selecting the default "Cpp."
- Upon page load or refresh, the content displayed is checked locally for defined preferences.
- If the user clicks "csharp" and it's not set at the time, the local value is rewritten to the local storage.
- This allows the user to view the same content after refreshing or reloading the page (for example, changing the page and returning).

**Please note:**
- This requires a setup of a "JavaScript" file that handles these globally, rather than being page-specific, as the latter would significantly degrade user and developer load times.
- Currently, all listed languages and their content should be included under the same file, specified with the div and an ID. Please note that this could change in the future, but currently, there are no solutions to address it as far as I'm aware.


Has Been fully addressed in
https://github.com/VerzatileDevOrg/Programming_HandBook/pull/68#issuecomment-1878000975

