### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# These are supported funding model platforms
+
+open_collective: # Replace with a single Open Collective username
+ko_fi: verzatiledev
+custom: ['https://paypal.me/verzatileDev?country.x=EE&locale.x=en_US']


### PR DESCRIPTION
Setup Sponsorship to be able to buy a Domain for the Handbook, As well as Potentially in the future enable Sponsoring of Maintainers.

Aims to Provide improvement and further development of the repository and the website.