### PR TITLE
Introducing: Article description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Programming Handbook
-description: Programming Snippets tricks docs
+description: An open-source platform for sharing and preserving programming knowledge. Discover code snippets, best practices, and resources, all continuously updated by a thriving community of developers. Join us to collaborate and enhance your coding skills in one comprehensive space.
 theme: just-the-docs
 
 url: https://just-the-docs.github.io

--- a/docs/Concepts/Algorithms/Algorithms.md
+++ b/docs/Concepts/Algorithms/Algorithms.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Algorithms
+description: An Article that explores algorithmic concepts, types, techniques and analysis of time complexity.
 nav_order: 1
 parent: Concepts
 has_children: false

--- a/docs/Concepts/Concepts.md
+++ b/docs/Concepts/Concepts.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Concepts
+description: An article dicussing the concept of programming concepts with a definition, use cases and history. Where additional Sub-topics go into the topics of each concept in detail.
 nav_order: 5
 has_children: true
 ---

--- a/docs/Concepts/DevOps/DevOps.md
+++ b/docs/Concepts/DevOps/DevOps.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: DevOps
+description: An article discussing the concept of DevOps and the utilization of platforms and environments in development.
 nav_order: 1
 parent: Concepts
 has_children: false

--- a/docs/Concepts/ECS/ECS.md
+++ b/docs/Concepts/ECS/ECS.md
@@ -1,12 +1,7 @@
 ---
 layout: default
 title: ECS
-description: “The page you are trying to access is currently under construction.
-Please check back later!
-
-Feel free to enhance and contribute to the content by clicking on the ‘Edit this page on GitHub’ link located at the bottom of the page.
-
-Thank you for your understanding and cooperation. "
+description: 
 nav_order: 1
 parent: Concepts
 has_children: false

--- a/docs/Concepts/ECS/ECS.md
+++ b/docs/Concepts/ECS/ECS.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: ECS
+description: 
 nav_order: 1
 parent: Concepts
 has_children: false

--- a/docs/Concepts/ECS/ECS.md
+++ b/docs/Concepts/ECS/ECS.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: ECS
-description: 
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Concepts
 has_children: false

--- a/docs/Concepts/ECS/ECS.md
+++ b/docs/Concepts/ECS/ECS.md
@@ -1,7 +1,12 @@
 ---
 layout: default
 title: ECS
-description: 
+description: “The page you are trying to access is currently under construction.
+Please check back later!
+
+Feel free to enhance and contribute to the content by clicking on the ‘Edit this page on GitHub’ link located at the bottom of the page.
+
+Thank you for your understanding and cooperation. "
 nav_order: 1
 parent: Concepts
 has_children: false

--- a/docs/Concepts/Inheritance/Inheritance.md
+++ b/docs/Concepts/Inheritance/Inheritance.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Inheritance
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Concepts
 has_children: false

--- a/docs/Concepts/Memory/Memory.md
+++ b/docs/Concepts/Memory/Memory.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Memory
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Concepts
 has_children: false

--- a/docs/Concepts/OOP/OOP.md
+++ b/docs/Concepts/OOP/OOP.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: OOP
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Concepts
 has_children: false

--- a/docs/Concepts/Polymorphism/Polymorphism.md
+++ b/docs/Concepts/Polymorphism/Polymorphism.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Polymorphism
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Concepts
 has_children: false

--- a/docs/Concepts/SOLID/SOLID.md
+++ b/docs/Concepts/SOLID/SOLID.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: SOLID
+description: An article discussing the concept of SOLID, its principles, types and definitions. Example code provides an overview of the concept by utalizing a coffing making method.
 nav_order: 1
 parent: Concepts
 has_children: false

--- a/docs/Engine/Engine.md
+++ b/docs/Engine/Engine.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Engine
+description: An article discussing about the use cases of video game engines, history and definition.
 nav_order: 4
 has_children: true
 ---

--- a/docs/Engine/GameMakerStudio/GameMakerStudio.md
+++ b/docs/Engine/GameMakerStudio/GameMakerStudio.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: GameMakerStudio
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Engine
 has_children: false

--- a/docs/Engine/Godot/Godot.md
+++ b/docs/Engine/Godot/Godot.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Godot
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Engine
 has_children: false

--- a/docs/Engine/Unity/Unity.md
+++ b/docs/Engine/Unity/Unity.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Unity
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Engine
 has_children: false

--- a/docs/Engine/UnrealEngine/UnrealEngine.md
+++ b/docs/Engine/UnrealEngine/UnrealEngine.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Unreal Engine
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Engine
 has_children: false

--- a/docs/Framework/DirectX/DirectX.md
+++ b/docs/Framework/DirectX/DirectX.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: DirectX
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Framework
 has_children: false

--- a/docs/Framework/Flutter/Flutter.md
+++ b/docs/Framework/Flutter/Flutter.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Flutter
+description: An article showcasing Flutter, a robust development kit framework. In this comprehensive exploration, we delve into its capabilities, features, and practical applications, offering detailed descriptions and illustrative examples.
 nav_order: 1
 parent: Framework
 has_children: false

--- a/docs/Framework/Framework.md
+++ b/docs/Framework/Framework.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Framework
+description: An article dicussing about Frameworks, an essential tool in software development with description, use cases and History.
 nav_order: 3
 has_children: true
 ---

--- a/docs/Framework/JUCE/JUCE.md
+++ b/docs/Framework/JUCE/JUCE.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: JUCE
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Framework
 has_children: false

--- a/docs/Framework/NET/net.md
+++ b/docs/Framework/NET/net.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: .NET
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Framework
 has_children: false

--- a/docs/Framework/OpenGL/OpenGL.md
+++ b/docs/Framework/OpenGL/OpenGL.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: OpenGL
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Framework
 has_children: false

--- a/docs/Framework/SFML/SFML.md
+++ b/docs/Framework/SFML/SFML.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: SFML
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Framework
 has_children: false

--- a/docs/IDE/AdobeDreamWeaver/AdobeDreamWeaver.md
+++ b/docs/IDE/AdobeDreamWeaver/AdobeDreamWeaver.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Adobe DreamWeaver
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: IDE
 has_children: false

--- a/docs/IDE/IDE.md
+++ b/docs/IDE/IDE.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: IDE
+description: An article about Integrated development environment (IDE) defining use cases, history and describtion.
 nav_order: 2
 has_children: true
 ---

--- a/docs/IDE/MonoDevelop/MonoDevelop.md
+++ b/docs/IDE/MonoDevelop/MonoDevelop.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: MonoDevelop
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: IDE
 has_children: false

--- a/docs/IDE/NetBeans/NetBeans.md
+++ b/docs/IDE/NetBeans/NetBeans.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: NetBeans
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: IDE
 has_children: false

--- a/docs/IDE/Notepad++/Notepad++.md
+++ b/docs/IDE/Notepad++/Notepad++.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Notepad++
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: IDE
 has_children: false

--- a/docs/IDE/Rider/Rider.md
+++ b/docs/IDE/Rider/Rider.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Rider
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: IDE
 has_children: false

--- a/docs/IDE/VSCode/VSCode.md
+++ b/docs/IDE/VSCode/VSCode.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: VSCode
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 parent: IDE
 has_children: false
 ---

--- a/docs/IDE/VisualStudio/ChangeProjectName.md
+++ b/docs/IDE/VisualStudio/ChangeProjectName.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Change Project Name
+description: An article discussing methods to transfer github enterprise account repositires into personal github repositires.
 nav_order: 1
 parent: Visual Studio
 grand_parent: IDE

--- a/docs/IDE/VisualStudio/IncludeDLLs.md
+++ b/docs/IDE/VisualStudio/IncludeDLLs.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Include DLLs
+description: An article demonstrating the use cases of DLL linking within visual studio. A practical use when dealing with programming libraries and code organization.
 nav_order: 2
 parent: Visual Studio
 grand_parent: IDE

--- a/docs/IDE/VisualStudio/VisualStudio.md
+++ b/docs/IDE/VisualStudio/VisualStudio.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Visual Studio
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: IDE
 has_children: true

--- a/docs/Language/C#/C#.md
+++ b/docs/Language/C#/C#.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: C#
+description: An article dicussing features, key releases and getting started topics about C# a modern, versatile, object-oriented programming language developed by Microsoft.
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/C++/Addresses.md
+++ b/docs/Language/C++/Addresses.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Addresses
+description: An article dicussing about c++ memory addresses.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C++/C++.md
+++ b/docs/Language/C++/C++.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: C++
+description: An article dicussing features, key releases and getting started topics about C++ a modern, versatile, object-oriented programming language developed by Microsoft.
 nav_order: 1
 parent: Language
 has_children: true

--- a/docs/Language/C++/ConstantPointerToConstant.md
+++ b/docs/Language/C++/ConstantPointerToConstant.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Constant Pointers To Constants
+description: An article dicussing about c++ Constant Pointers To Constants, its benefits and basic examples.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C++/ConstantPointers.md
+++ b/docs/Language/C++/ConstantPointers.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Constant Pointers
+description: An article dicussing about c++ constant pointers, its benefits and basic examples.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C++/Dereferencing.md
+++ b/docs/Language/C++/Dereferencing.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Dereferencing
+description: An article dicussing about c++ Dereferencing, with basic examples.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C++/MemberPointers.md
+++ b/docs/Language/C++/MemberPointers.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Member Pointers
+description: An article dicussing about c++ Member Pointers, with basic examples.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C++/MultilevelPointers.md
+++ b/docs/Language/C++/MultilevelPointers.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Multilevel Pointers
+description: An article dicussing about c++ Multi-level Pointers, with basic examples.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C++/NullPointers.md
+++ b/docs/Language/C++/NullPointers.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Null Pointers
+description: An article dicussing about c++ Null Pointers, with basic examples.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C++/PointerToConstant.md
+++ b/docs/Language/C++/PointerToConstant.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Pointers To Constants
+description: An article dicussing about c++ Pointers To Constants, with basic examples.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C++/Pointers.md
+++ b/docs/Language/C++/Pointers.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Pointers
+description: An article dicussing about c++ Pointers, with basic examples.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C++/RawPointers.md
+++ b/docs/Language/C++/RawPointers.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Raw Pointers
+description: An article dicussing about c++ Raw Pointers, with basic examples.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C++/References.md
+++ b/docs/Language/C++/References.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: References
+description: An article dicussing about c++ References, with basic examples.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C++/SmartPointers.md
+++ b/docs/Language/C++/SmartPointers.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Smart Pointers
+description: An article dicussing about c++ Smart Pointers, with basic examples.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C++/VoidPointers.md
+++ b/docs/Language/C++/VoidPointers.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Void Pointers
+description: An article dicussing about c++ Void Pointers, with basic examples.
 nav_order: 1
 parent: C++
 grand_parent: Language

--- a/docs/Language/C/C.md
+++ b/docs/Language/C/C.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: C
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/CSS/CSS.md
+++ b/docs/Language/CSS/CSS.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: CSS
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/Dart/Dart.md
+++ b/docs/Language/Dart/Dart.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Dart
+description: An article dicussing about the programming language dart, with description and basic examples.
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/GO/GO.md
+++ b/docs/Language/GO/GO.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: GO
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/HTML/HTML.md
+++ b/docs/Language/HTML/HTML.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: HTML
+description: An article dicussing about the markup language HTML with a description and basic exmaples.
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/Haxe/Haxe.md
+++ b/docs/Language/Haxe/Haxe.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Haxe
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/JS/JS.md
+++ b/docs/Language/JS/JS.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: JS
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/Java/Java.md
+++ b/docs/Language/Java/Java.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Java
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/Language.md
+++ b/docs/Language/Language.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Language
+description: An article dicussing about programming languages with a definition, use cases and History.
 nav_order: 2
 has_children: true
 ---

--- a/docs/Language/Lisp/Lisp.md
+++ b/docs/Language/Lisp/Lisp.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Lisp
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/Lua/Lua.md
+++ b/docs/Language/Lua/Lua.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Lua
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/Python/Python.md
+++ b/docs/Language/Python/Python.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Python
+description: An article dicussing about a programming language known as Python, with features, key releases, getting started and basic examples.
 nav_order: 1
 parent: Language
 has_children: true

--- a/docs/Language/Python/Tries.md
+++ b/docs/Language/Python/Tries.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Tries
+description: An article dicussing about python's data structure known as Tries with a description, use cases and considerations.
 nav_order: 1
 parent: Python
 grand_parent: Language

--- a/docs/Language/React/React.md
+++ b/docs/Language/React/React.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: React
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/Ruby/Ruby.md
+++ b/docs/Language/Ruby/Ruby.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Ruby
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/Language/Rust/Rust.md
+++ b/docs/Language/Rust/Rust.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Rust
+description: An article dicussing about a programming language known as rust, with definition and basic examples.
 nav_order: 1
 parent: Language
 has_children: false

--- a/docs/VersionControl/Git/Git.md
+++ b/docs/VersionControl/Git/Git.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Git
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Version Control
 has_children: false

--- a/docs/VersionControl/Git/GitBash.md
+++ b/docs/VersionControl/Git/GitBash.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: GitBash
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Version Control
 has_children: false

--- a/docs/VersionControl/Git/Github.md
+++ b/docs/VersionControl/Git/Github.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Github
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Version Control
 has_children: true

--- a/docs/VersionControl/Git/Github/EnterpriseToPersonal.md
+++ b/docs/VersionControl/Git/Github/EnterpriseToPersonal.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Transfer Enterprise to Personal Github
+description: An article dicussing about the steps to transfer an enterprise account's repositories to personal repositories on github.
 nav_order: 1
 parent: Github
 grand_parent: Version Control

--- a/docs/VersionControl/Git/Gitlab.md
+++ b/docs/VersionControl/Git/Gitlab.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Gitlab
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Version Control
 has_children: false

--- a/docs/VersionControl/P4V/Helix.md
+++ b/docs/VersionControl/P4V/Helix.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Helix
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Version Control
 has_children: false

--- a/docs/VersionControl/P4V/HelixSwarm.md
+++ b/docs/VersionControl/P4V/HelixSwarm.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: HelixSwarm
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Version Control
 has_children: false

--- a/docs/VersionControl/P4V/Perforce.md
+++ b/docs/VersionControl/P4V/Perforce.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Perforce
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Version Control
 has_children: false

--- a/docs/VersionControl/PlasticSCM/Plastic.md
+++ b/docs/VersionControl/PlasticSCM/Plastic.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Plastic
+description: "Warning: The following page is currently under construction, find more about the details in future patches, or if you choose to add in the article see info on the bottom of the page."
 nav_order: 1
 parent: Version Control
 has_children: false

--- a/docs/VersionControl/VersionControl.md
+++ b/docs/VersionControl/VersionControl.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Version Control
+description: An article dicussing about version control, with definition, use cases, History.
 nav_order: 6
 has_children: true
 ---


### PR DESCRIPTION
Changes
---

The following change introduces:

- Default Article / Page description 
- Page-specific description

(The following is aimed at introducing a basic summary of the topic at hand, to showcase to the user that has received the URL of the platform chosen to improve user experience and attach the readers to the given articles).

Note:
---

Please Use Squash Merge for the Merge upon review.

- This limits it to 1 commit instead of multiple, that is not necessary to be shown.