### PR TITLE
Update issue templates (Fix /Add)

### DIFF
--- a/.github/ISSUE_TEMPLATE/article-writing.md
+++ b/.github/ISSUE_TEMPLATE/article-writing.md
@@ -1,0 +1,17 @@
+---
+name: Article Writing
+about: Have a question about the structure of articles or how to add pages.
+title: "[Article Q] - "
+labels: ''
+assignees: ''
+
+---
+
+**Question on the topic **
+
+- Describe the issue or a question you have for writing articles.
+
+**Additional Notes:**
+
+- Describe your references and what you have read previously regarding the topic..
+- Or explain if there are any changes required (Possibly add solutions or ideas on how to do it).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,26 +1,33 @@
 ---
 name: Bug Report
-about: Submit a Bug Report if you find something in our site not working as it should be (such as our webpages not loading)! For content issues, please use a Content Report!
-title: ''
+about: Submit a Bug Report if you find something in our site not working as it should
+  be (such as our webpages not loading)! For content issues, please use a Content
+  Report!
+title: "[BUG] - "
 labels: ''
 assignees: ''
 
 ---
 
 **Description**
+
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior:
+
+Steps to reproduce the behaviour:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+**Expected behaviour**
+
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
+
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
@@ -29,10 +36,12 @@ If applicable, add screenshots to help explain your problem.
  - Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
+
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
 **Additional context**
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/content-report.md
+++ b/.github/ISSUE_TEMPLATE/content-report.md
@@ -1,9 +1,8 @@
 ---
 name: Content Report
-about: Submit a Content Report if you find something wrong with the content within a page, ie Copyrights, Grammar, False Information or broken links to academic sources! For functional issues (such as our website not working), please use a Bug Report! 
-  its explained).
-title: ''
-labels: 'Content: Issue'
+about: " ie Copyrights, Grammar, False Info, broken links! "
+title: "[ContentR] - "
+labels: ''
 assignees: VerzatileDev
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,24 @@
 ---
 name: Feature Request
-about: Suggest an idea for this project
-title: ''
+about: Suggest an idea
+title: "[Feature] - "
 labels: ''
 assignees: ''
 
 ---
 
 **Description:**
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 **Proposed Solution:**
+
 A clear and concise description of what you want to happen.
 
 **Alternatives:**
+
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Additional Context**
+
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Addresses templates with a default Title to Begin with.

Changes descriptions and its formatting slightly

- New addition of " Article Writing " for the people that might have questions in regards to adding new pages,  or information required on the page.

- Fixes an issue with Content Report ( Too long of a description).