### PR TITLE
Fix a permalik suffix to remove .html

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 title: Programming Handbook
 description: An open-source platform for sharing and preserving programming knowledge. Discover code snippets, best practices, and resources, all continuously updated by a thriving community of developers. Join us to collaborate and enhance your coding skills in one comprehensive space.
 theme: just-the-docs
+permalink: pretty
 
 url: https://just-the-docs.github.io
 


### PR DESCRIPTION
The following change is based on the information provided at:

-  https://jekyllrb.com/docs/permalinks/
- Removes suffix " .HTML "

(When a page is located at " Resource/myPage.html " it converts it to -> /myPage/ )

